### PR TITLE
fix problem when trying to calculate the maximum of two empty clocks

### DIFF
--- a/src/vectorclock.erl
+++ b/src/vectorclock.erl
@@ -88,6 +88,7 @@ max([V1, V2 | T]) -> max([max2(V1, V2) | T]).
 
 %% component-wise maximum of two clocks
 -spec max2(vectorclock(), vectorclock()) -> vectorclock().
+max2(#{},#{}) -> new();
 max2(V1, V2) ->
   FoldFun =
     fun(DC, A, Acc) ->


### PR DESCRIPTION
Currently, when you try to call `max([vc1, vc2])` when both vector clocks are empty, the module crashes. This fixes the problem by simply returning an empty vector clock in this case.